### PR TITLE
Fix D805/6 Modem Version

### DIFF
--- a/D805-RAMDISK/init.baseband.rc
+++ b/D805-RAMDISK/init.baseband.rc
@@ -1,0 +1,12 @@
+#
+#  SET BASEBAND VERSION FOR
+#  UNOFFICIAL LP G2 DEVICES
+#
+	
+service baseband-fix /system/bin/sh /init.baseband.sh
+    class late_start
+    user root
+    oneshot
+
+on boot
+	start baseband-fix

--- a/D805-RAMDISK/init.baseband.sh
+++ b/D805-RAMDISK/init.baseband.sh
@@ -1,0 +1,8 @@
+#!/sbin/busybox sh
+#
+#  SET BASEBAND VERSION FOR
+#  UNOFFICIAL LP G2 DEVICES
+#
+
+# grep the modem partition for baseband version and set it
+setprop ro.lge.basebandversion `strings /firmware/image/modem.b21 | grep "^M8974A-" | head -1`

--- a/D805-RAMDISK/init.g2.rc
+++ b/D805-RAMDISK/init.g2.rc
@@ -5,7 +5,10 @@ import /init.qcom.rc
 import /init.lge.usb.rc
 import /init.galbi2_core.rc
 import /init.lge.power.rc
+
+# RADIO FIX
 import /init.cloudy.rc
+import /init.baseband.rc
 
 # LGE_CHANGE_S, [LGE_DATA][LGP_DATA_TCPIP_NSRM], heeyeon.nah@lge.com, 2012-05-22
 export LD_PRELOAD /vendor/lib/libNimsWrap.so


### PR DESCRIPTION
It greps the baseband version from modem partition.
Should work now. I saw that original cloudy script sets modem version.
So, I use oppo method to get baseband version and then, set it.
